### PR TITLE
将发送邮件的参数由文件中存储改为在 URL 中传递

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -32,23 +32,16 @@ class CommentToMail_Action extends Typecho_Widget implements Widget_Interface_Do
     /**
      * 读取缓存文件内容
      */
-    public function process($fileName)
+    public function process($comment, $token)
     {
         $this->init();
-        //获取评论内容
-        $file = $this->_dir . '/cache/' . $fileName;
-        if (file_exists($file)) {
-            $this->_email = unserialize(file_get_contents($file));
-            @unlink($file);
 
-            if (!$this->_user->simpleLogin($this->_email->ownerId)) {
-                $this->widget('Widget_Archive@404', 'type=404')->render();
-                exit;
-            }
-        } else {
-            $this->widget('Widget_Archive@404', 'type=404')->render();
+        // 验证 url 中的 token 和设置的 token 是否一致
+        if(strcmp($token, Helper::options()->plugin('CommentToMail')->token)){
             exit;
         }
+        //获取评论内容
+        $this->_email = $comment;
         
         //如果本次评论设置了拒收邮件，把coid加入拒收列表
         if ($this->_email->banMail) {
@@ -403,6 +396,6 @@ class CommentToMail_Action extends Typecho_Widget implements Widget_Interface_Do
     {
         $this->on($this->request->is('do=testMail'))->testMail();
         $this->on($this->request->is('do=editTheme'))->editTheme($this->request->edit);
-        $this->on($this->request->is('send'))->process($this->request->send);
+        $this->on($this->request->is('send'))->process(json_decode(base64_decode($this->request->send)), $this->request->token);
     }
 }


### PR DESCRIPTION
在很多环境中本地并不支持文件写操作，比如各种 app engine，大大限制了插件的使用场景，将发送邮件的本地写文件去除后应该可以在各个平台上都无障碍运行了。同时为了防止发送邮件的 URL 泄露造成邮件滥发，还增加了 token 机制，每次都要验证 URL 中的 token 和设置中的 token 是否一致。