### PR TITLE
修复自定义后台路径后引起的管理评论链接不正确问题

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -176,7 +176,7 @@ class CommentToMail_Plugin implements Typecho_Plugin_Interface
             'permalink' => $comment->permalink,
             'status'    => $comment->status,
             'parent'    => $comment->parent,
-            'manage'    => $options->siteUrl . 'admin/manage-comments.php'
+            'manage'    => $options->siteUrl ."..".__TYPECHO_ADMIN_DIR__."manage-comments.php"
         );
 
         self::$_isMailLog = in_array('to_log', Helper::options()->plugin('CommentToMail')->other) ? true : false;


### PR DESCRIPTION
插件中对 {manage} 的替换固定为 `$options->siteUrl . "admin/manage-comments.php"`，如果自定义后台地址则会出现邮件内容中管理评论地址不正确。修改为 `$options->siteUrl ."..".__TYPECHO_ADMIN_DIR__."manage-comments.php"`